### PR TITLE
Develop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orm_macro"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 authors = ["Josue <josuebarretogit@gmail.com>"]
 repository = "https://github.com/josueBarretogit/my_orm"
@@ -11,12 +11,7 @@ license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+
 [dependencies]
-orm_macro_derive = { version="1.2.0",  path = "orm_macro_derive" }
+orm_macro_derive = { version="1.2.1",  path = "./orm_macro_derive/" }
 
-
-[features]
-default = ["postgres"]
-postgres = []
-mysql = []
-sqlite = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orm_macro"
-version = "1.2.3"
+version = "1.2.0"
 edition = "2021"
 authors = ["Josue <josuebarretogit@gmail.com>"]
 repository = "https://github.com/josueBarretogit/my_orm"
@@ -12,7 +12,7 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-orm_macro_derive = { version="1.1.3",  path = "orm_macro_derive" }
+orm_macro_derive = { version="1.2.0",  path = "orm_macro_derive" }
 
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orm_macro"
-version = "1.1.3"
+version = "1.2.3"
 edition = "2021"
 authors = ["Josue <josuebarretogit@gmail.com>"]
 repository = "https://github.com/josueBarretogit/my_orm"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,10 @@ license = "MIT"
 
 [dependencies]
 orm_macro_derive = { version="1.1.3",  path = "orm_macro_derive" }
+
+
+[features]
+default = ["postgres"]
+postgres = []
+mysql = []
+sqlite = []

--- a/README.md
+++ b/README.md
@@ -1,12 +1,40 @@
-Tired of learning super complex Orms? bored of doing sqlbuilder.select("fields").from("table")? 
-sometimes you just want a quick, easy to use sql statement that matches your structs definitions even if it changes, well this crate is for you 
+Tired of learning super complex Orms? bored of doing sqlbuilder.select("fields").from("table") (which becomes outdated as your code evolves)? 
+sometimes you just want a quick, easy to use sql statement that matches your structs definitions even if it 
+changes, well this crate is for you 
 
-Currently this only supports postgres
+# Table of contents
 
-## Usage examples
+ 1. [Installation](#Installation)
+ 2. [Usage](#Usage)
+* [Find method](#Find)
+* [Create method](#Create)
+* [Update method](#Update)
+* [Delete method](#Delete)
+ 
 
+## Installation
+
+put this in your cargo.toml: 
+```rust 
+orm_macro = version = "1.2.0"
+orm_macro_derive =  version = "1.2.0" 
+```
+
+The feature flag enabled by default is "postgres" which uses postgres style bindings, for example: 
+```sql
+DELETE FROM table WHERE id = $1 # postgres bindings
+DELETE FROM table WHERE id = ? # this bindings are used by mysql and sqlite
+```
+If you want to use mysql bindings then in your cargo.toml
 ```rust
+orm_macro = { version = "1.2.0", features = ["mysql"] }
+orm_macro_derive = { version = "1.2.0", features = ["mysql"] } 
+```
 
+## Usage
+I will be using this structs as examples and sqlx as a database driver
+```rust
+///bring this to scope
 use orm_macro::OrmRepository;
 use orm_macro_derive::GetRepository;
 
@@ -37,69 +65,75 @@ pub struct BooksCreateDto {
     pub description: Option<String>,
 }
 
-pub struct BookRepository {}
+```
+## Find 
 
-impl BookRepository {
-    async fn update(&self, body : BooksUpdateDto) -> Result<Vec<Books>, sqlx::Error> {
-
-        /// this would generate: UPDATE books SET description = $1 WHERE id = $2 RETURNING id, description
-        let sql =  BooksUpdateDtoOrm::builder().update();
-
-        let db_response = sqlx::query_as(sql.as_str())
-        .bind(body.description)
-        .fetch_all(&*self.db)
-        .await?;
-
-
-        Ok(db_response)
-    }
-
-
-     async fn create(&self, body : BooksCreateDto) -> Result<Vec<Books>, sqlx::Error> {
-
-        /// this would generate: INSERT INTO books (title,description) VALUES($1,$2) RETURNING id,title,description
-        let sql =  BooksCreateDtoOrm::builder().create();
-
-        let db_response = sqlx::query_as(sql.as_str())
-        .bind(body.title)
-        .bind(body.description)
-        .fetch_one(&*self.db)
-        .await?;
-
-
-        Ok(db_response)
-    }
-
-
-    async fn delete(&self,  id: i64 ) -> Result<Vec<Books>, sqlx::Error> {
-
-        /// this would generate: DELETE FROM books WHERE id = $1  RETURNING id,title,description,author_name
-        let sql =  BooksOrm::builder().delete();
-
-        let db_response = sqlx::query_as(sql.as_str())
-        .bind(id)
-        .fetch_one(&*self.db)
-        .await?;
-
-
-        Ok(db_response)
-    }
-
-    async fn find_all(&self) -> Result<Vec<Books>, sqlx::Error> {
+``` rust 
+async fn find_all() -> Result<Vec<Books>, sqlx::Error> {
 
         /// this would generate: SELECT id,description,title FROM books 
         ///since it is a string you can use it with any sql driver
         let sql =  BooksOrm::builder().find();
-
         let db_response = sqlx::query_as(sql.as_str())
+        .fetch_all(&executor)
+        .await?;
+
+        Ok(db_response)
+  }
+
+ ```
+
+## Create
+
+```rust
+async fn create(&self, body : BooksCreateDto) -> Result<Vec<Books>, sqlx::Error> {
+        let builder =  BooksCreateDtoOrm::builder();
+
+		/// this would generate: INSERT INTO books (title,description) VALUES($1,$2) RETURNING id,title,description
+		let sql = builder.create();
+
+        let db_response = sqlx::query_as(sql)
+        .bind(body.title)
+        .bind(body.description)
+        .fetch_one(&executor)
+        .await?;
+
+        Ok(db_response)
+ }
+```
+
+## Update
+```rust
+    async fn update(body : BooksUpdateDto) -> Result<Vec<Books>, sqlx::Error> {
+
+        /// this would generate: UPDATE books SET description = $1 WHERE id = $2 RETURNING id, description
+        let builder =  BooksUpdateDtoOrm::builder();
+		let sql = builder.update();
+
+        let db_response = sqlx::query_as(sql))
+        .bind(body.description)
         .fetch_all(&*self.db)
         .await?;
 
 
         Ok(db_response)
     }
-
-}
-    
-
 ```
+## Delete
+
+```rust
+    async fn delete(id: i64) -> Result<Vec<Books>, sqlx::Error> {
+        let builder =  BooksOrm::builder();
+		/// this would generate: DELETE FROM books WHERE id = $1  RETURNING id,title,description,author_name
+		let sql = builder.delete();
+		
+        let db_response = sqlx::query_as(sql)
+        .bind(id)
+        .fetch_one(&*self.db)
+        .await?;
+
+        Ok(db_response)
+    }
+```
+
+Please suggest features or report bugs in the issues tabs

--- a/README.md
+++ b/README.md
@@ -102,6 +102,4 @@ impl BookRepository {
 }
     
 
-
-
 ```

--- a/README.md
+++ b/README.md
@@ -16,19 +16,19 @@ changes, well this crate is for you
 
 put this in your cargo.toml: 
 ```rust 
-orm_macro = version = "1.2.0"
-orm_macro_derive =  version = "1.2.0" 
+orm_macro = "1.2.1"
+orm_macro_derive = { version = "1.2.1", features = ["postgres"] }  
 ```
 
-The feature flag enabled by default is "postgres" which uses postgres style bindings, for example: 
+The feature flag  "postgres"  uses postgres style bindings, for example: 
 ```sql
 DELETE FROM table WHERE id = $1 # postgres bindings
 DELETE FROM table WHERE id = ? # this bindings are used by mysql and sqlite
 ```
 If you want to use mysql bindings then in your cargo.toml
 ```rust
-orm_macro = { version = "1.2.0", features = ["mysql"] }
-orm_macro_derive = { version = "1.2.0", features = ["mysql"] } 
+orm_macro =  "1.2.1"
+orm_macro_derive = { version = "1.2.1", features = ["mysql"] } 
 ```
 
 ## Usage

--- a/orm_macro_derive/Cargo.toml
+++ b/orm_macro_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orm_macro_derive"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 authors = ["Josue <josuebarretogit@gmail.com>"]
 repository = "https://github.com/josueBarretogit/my_orm"
@@ -21,7 +21,6 @@ quote = "1.0.36"
 syn = "2.0.60"
 
 [features]
-default = ["postgres"]
 postgres = []
 mysql = []
 sqlite = []

--- a/orm_macro_derive/Cargo.toml
+++ b/orm_macro_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orm_macro_derive"
-version = "1.1.3"
+version = "1.2.3"
 edition = "2021"
 authors = ["Josue <josuebarretogit@gmail.com>"]
 repository = "https://github.com/josueBarretogit/my_orm"

--- a/orm_macro_derive/Cargo.toml
+++ b/orm_macro_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orm_macro_derive"
-version = "1.2.3"
+version = "1.2.0"
 edition = "2021"
 authors = ["Josue <josuebarretogit@gmail.com>"]
 repository = "https://github.com/josueBarretogit/my_orm"

--- a/orm_macro_derive/Cargo.toml
+++ b/orm_macro_derive/Cargo.toml
@@ -16,5 +16,6 @@ license = "MIT"
 proc-macro = true
 
 [dependencies]
+proc-macro2 = "1.0.81"
 quote = "1.0.36"
 syn = "2.0.60"

--- a/orm_macro_derive/Cargo.toml
+++ b/orm_macro_derive/Cargo.toml
@@ -19,3 +19,9 @@ proc-macro = true
 proc-macro2 = "1.0.81"
 quote = "1.0.36"
 syn = "2.0.60"
+
+[features]
+default = ["postgres"]
+postgres = []
+mysql = []
+sqlite = []

--- a/orm_macro_derive/src/lib.rs
+++ b/orm_macro_derive/src/lib.rs
@@ -56,15 +56,29 @@ pub fn get_repository(struc: TokenStream) -> TokenStream {
 fn impl_repository(struc_data: StructData) -> TokenStream {
     let orm_struct_name = struc_data.struct_name;
 
+    //for update sql statement we dont want the id to appear
+    let fields_ignoring_id : Vec<String> = struc_data.fields.iter().filter(|field| *field != "id").map(|field| field.to_string()).collect();
+
+    
+    let mut update_where_condition  = String::new();
+    update_where_condition.push_str(format!("id = ${}", fields_ignoring_id.len() + 1).as_str());
+
+
+    let mut update_builder = UpdateStatement::new(&struc_data.table_name, WhereClause::new());
+
+    update_builder.set_fields(fields_ignoring_id.clone())
+        .set_where(vec![update_where_condition])
+        .set_returning_clause(ReturningClause::new(&fields_ignoring_id));
+
     let mut select_builder = SelectStatement::new(&struc_data.fields, &struc_data.table_name);
 
-    let mut update_builder = UpdateStatement::new(&struc_data.fields, &struc_data.table_name, WhereClause::new());
 
-    update_builder.set_returning_clause(ReturningClause::new(&struc_data.fields));
 
     let mut delete_builder = DeleteStatement::new(&struc_data.table_name, WhereClause::new());
 
-    let mut insert_builder = InsertStatement::new(&struc_data.table_name, &struc_data.fields);
+    let mut insert_builder = InsertStatement::new(&struc_data.table_name, &fields_ignoring_id, fields_ignoring_id.clone());
+
+    insert_builder.set_returning_clause(ReturningClause::new(&fields_ignoring_id));
 
     let select_statement = select_builder.build_sql();
     let update_statement = update_builder.build_sql();

--- a/orm_macro_derive/src/lib.rs
+++ b/orm_macro_derive/src/lib.rs
@@ -72,9 +72,10 @@ fn impl_repository(struc_data: StructData) -> TokenStream {
 
     let mut select_builder = SelectStatement::new(&struc_data.fields, &struc_data.table_name);
 
-
-
     let mut delete_builder = DeleteStatement::new(&struc_data.table_name, WhereClause::new());
+
+    delete_builder.set_returning_clause(ReturningClause::new(&fields_ignoring_id));
+
 
     let mut insert_builder = InsertStatement::new(&struc_data.table_name, &fields_ignoring_id, fields_ignoring_id.clone());
 

--- a/orm_macro_derive/src/utils.rs
+++ b/orm_macro_derive/src/utils.rs
@@ -1,8 +1,165 @@
 /// The input will have the form: atribbute("atribbute to extract")
-pub fn extract_string_atribute(input : String) -> String {
-
+pub fn extract_string_atribute(input: String) -> String {
     let index_c1 = input.find('(').unwrap();
     let index_c2 = input.find(')').unwrap();
 
     input[(index_c1 + 1)..index_c2].replace("\"", "")
+}
+
+pub trait SqlBuilder {
+    fn build_sql(self) -> String;
+}
+
+pub struct SelectStatement {
+    select_fields: Vec<String>,
+    from_table: String,
+    where_clause: Option<WhereClause>,
+}
+
+pub struct UpdateStatement {
+    set_fields: Vec<String>,
+    update_table_name: String,
+    where_clause: Option<WhereClause>,
+    returning_clause: Option<ReturningClause>,
+}
+
+pub struct InsertStatement {
+    table_name: String,
+    insert_fields: Vec<String>,
+    values: Vec<String>,
+    returning_clause: Option<ReturningClause>,
+}
+
+pub struct DeleteStatement {
+    table_name: String,
+    where_clause: WhereClause,
+    returning_clause: Option<ReturningClause>,
+}
+
+pub struct WhereClause {
+    conditions: Vec<String>,
+}
+
+pub struct ReturningClause {
+    fields: Vec<String>,
+}
+
+impl SelectStatement {
+    pub fn set_where(&mut self, where_clause: WhereClause) -> &mut Self {
+        self.where_clause = Some(where_clause);
+        self
+    }
+
+    pub fn new(select_fields: &Vec<String>, from_table: &str) -> Self {
+        Self {
+            select_fields: select_fields.to_owned(),
+            from_table: from_table.to_owned(),
+            where_clause: None,
+        }
+    }
+}
+
+impl SqlBuilder for SelectStatement {
+    fn build_sql(self) -> String {
+        let mut fields: String = self
+            .select_fields
+            .iter()
+            .map(|field| format!("{},", field))
+            .collect();
+
+        fields.pop();
+
+        let where_clause = match self.where_clause {
+            Some(where_clause_builder) => where_clause_builder.build_sql(),
+            None => "".into(),
+        };
+
+        format!(
+            "SELECT {} from {} {}",
+            fields, self.from_table, where_clause
+        )
+    }
+}
+
+impl WhereClause {
+    pub fn set_conditions(&mut self, conditions: Vec<String>) -> &mut Self {
+        self.conditions = conditions;
+        self
+    }
+    pub fn new() -> Self {
+        Self {
+            conditions: vec!["".to_string()],
+        }
+    }
+}
+
+impl SqlBuilder for WhereClause {
+    fn build_sql(self) -> String {
+        format!("WHERE ")
+    }
+}
+
+impl UpdateStatement {
+    pub fn new(set_fields: &Vec<String>, update_table_name: &str) -> Self {
+        Self {
+            set_fields: set_fields.to_owned(),
+            update_table_name: update_table_name.to_owned(),
+            where_clause: None,
+            returning_clause: None,
+        }
+    }
+}
+
+impl SqlBuilder for UpdateStatement {
+    fn build_sql(self) -> String {
+        format!("UPDATE ")
+    }
+}
+
+impl DeleteStatement {
+    pub fn new(table_name: &str, where_clause: WhereClause) -> Self {
+        Self {
+            table_name: table_name.to_owned(),
+            where_clause,
+            returning_clause: None,
+        }
+    }
+}
+
+impl SqlBuilder for DeleteStatement {
+    fn build_sql(self) -> String {
+        format!(
+            "DELETE FROM {} {}",
+            self.table_name,
+            self.where_clause.build_sql()
+        )
+    }
+}
+
+impl InsertStatement {
+    pub fn new(table_name: &str, insert_fields: &Vec<String>) -> Self {
+        Self {
+            table_name: table_name.to_owned(),
+            insert_fields: insert_fields.to_owned(),
+            values: vec![],
+            returning_clause: None,
+        }
+    }
+}
+
+impl SqlBuilder for InsertStatement {
+    fn build_sql(self) -> String {
+
+        let mut fields_to_insert = String::new(); 
+        let mut values_to_insert = String::new(); 
+
+        self.insert_fields.iter().enumerate().for_each(|(index, field)| {
+
+            fields_to_insert.push_str(format!("{},", field).as_str());
+            values_to_insert.push_str(format!("${}", index).as_str());
+
+        });
+
+        format!("INSERT INTO {} ({}) VALUES ({})", self.table_name, fields_to_insert, values_to_insert)
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ mod tests {
     #[test]
     fn find_method_build_select_sql() {
         assert_eq!(
-            "SELECT title,others FROM entity",
+            "SELECT title,others FROM entity ",
             EntityFindDtoOrm::builder().find()
         )
     }
@@ -61,7 +61,7 @@ mod tests {
     #[test]
     fn find_method_build_select_sql_with_main() {
         assert_eq!(
-            "SELECT id,title,description,others,another_property FROM entity",
+            "SELECT id,title,description,others,another_property FROM entity ",
             EntityOrm::builder().find()
         )
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,7 @@ mod tests {
         )
     }
 
+    #[cfg(feature = "postgres")]
     #[test]
     fn create_method_build_insert_sql_with_main_entity() {
         assert_eq!(
@@ -74,6 +75,17 @@ mod tests {
     )
     }
 
+    #[cfg(not(feature = "postgres"))]
+    #[test]
+    fn create_method_build_insert_sql_with_main_entity_mysql_bindings() {
+        assert_eq!(
+    "INSERT INTO entity (title,description,others,another_property) VALUES (?,?,?,?) RETURNING id,title,description,others,another_property",
+    EntityOrm::builder().create()
+    )
+    }
+
+
+    #[cfg(feature = "postgres")]
     #[test]
     fn create_method_build_insert_sql() {
         assert_eq!(
@@ -82,6 +94,18 @@ mod tests {
         )
     }
 
+
+    #[cfg(not(feature = "postgres"))]
+    #[test]
+    fn create_method_build_insert_mysql_bindings() {
+        assert_eq!(
+            "INSERT INTO entity (description) VALUES (?) RETURNING id,description",
+            EntityCreateDtoOrm::builder().create()
+        )
+    }
+
+
+    #[cfg(feature = "postgres")]
     #[test]
     fn delete_method_build_delete_sql() {
         assert_eq!(
@@ -90,14 +114,39 @@ mod tests {
     )
     }
 
+    #[cfg(not(feature = "postgres"))]
+    #[test]
+    fn delete_method_build_delete_sql_mysql_bindings() {
+        assert_eq!(
+    "DELETE FROM entity WHERE id = ? RETURNING id,title,description,others,another_property",
+    EntityOrm::builder().delete()
+    )
+    }
+
+
+    #[cfg(feature = "postgres")]
     #[test]
     fn update_method_builds_sql() {
         assert_eq!(
     "UPDATE entity SET title = $1,description = $2 WHERE id = $3 RETURNING id,title,description",
     EntityUpdateDtoOrm::builder().update()
     )
+
     }
 
+    #[cfg(not(feature = "postgres"))]
+    #[test]
+    fn update_method_builds_sql_mysql_bindings() {
+        assert_eq!(
+    "UPDATE entity SET title = ?,description = ? WHERE id = ? RETURNING id,title,description",
+    EntityUpdateDtoOrm::builder().update()
+    )
+    }
+
+
+
+
+    #[cfg(feature = "postgres")]
     #[test]
     fn update_method_builds_sql_with_main() {
         assert_eq!(
@@ -105,4 +154,14 @@ mod tests {
     EntityOrm::builder().update()
     )
     }
+
+    #[cfg(not(feature = "postgres"))]
+    #[test]
+    fn test_update_query_with_mysql_binding() {
+        assert_eq!(
+    "UPDATE entity SET title = ?,description = ?,others = ?,another_property = ? WHERE id = ? RETURNING id,title,description,others,another_property",
+        EntityOrm::builder().update()
+    )
+    }
+
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ pub trait OrmRepository {
     /// generate: SELECT {struct_fields} from {table_name}
     fn find(&self) -> String;
     ///Used to specify which fields to select
-    #[deprecated(since="1.2.3", note="Removing this unnecesary method will make find() return &str instead of String, in the future there will be better find methods")]
+    #[deprecated(since="1.2.0", note="Removing this unnecesary method will make find() return &str instead of String, in the future there will be better find methods")]
     fn select_fields(&mut self, fields: Vec<&str>) -> &mut Self;
     /// generate: INSERT INTO {table_name} ({struct_fields}) VALUES({$1,$2...}) RETURNING
     /// {struct_fields}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,10 @@ extern crate orm_macro_derive;
 ///This trait contains the methods that generate sql
 pub trait OrmRepository {
     /// generate: SELECT {struct_fields} from {table_name}
-    fn find(&self) -> &str;
+    fn find(&self) -> String;
+    ///Used to specify which fields to select
+    #[deprecated(since="1.2.3", note="Removing this unnecesary method will make find() return &str instead of String, in the future there will be better find methods")]
+    fn select_fields(&mut self, fields: Vec<&str>) -> &mut Self;
     /// generate: INSERT INTO {table_name} ({struct_fields}) VALUES({$1,$2...}) RETURNING
     /// {struct_fields}
     fn create(&mut self) -> &str;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,8 +69,7 @@ mod tests {
     #[test]
     fn create_method_build_insert_sql_with_main_entity() {
         assert_eq!(
-    "INSERT INTO entity (title,description,others,another_property) VALUES ($1,$2,$3,$4) RETURNING
-    id,title,description,others,another_property",
+    "INSERT INTO entity (title,description,others,another_property) VALUES ($1,$2,$3,$4) RETURNING id,title,description,others,another_property",
     EntityOrm::builder().create()
     )
     }
@@ -102,8 +101,7 @@ mod tests {
     #[test]
     fn update_method_builds_sql_with_main() {
         assert_eq!(
-    "UPDATE entity SET title = $1,description = $2,others = $3, another_property = $4 WHERE id = $5 RETURNING
-    id,title,description,others,another_property",
+    "UPDATE entity SET title = $1,description = $2,others = $3,another_property = $4 WHERE id = $5 RETURNING id,title,description,others,another_property",
     EntityOrm::builder().update()
     )
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,18 +3,15 @@ extern crate orm_macro_derive;
 ///This trait contains the methods that generate sql
 pub trait OrmRepository {
     /// generate: SELECT {struct_fields} from {table_name}
-    fn find(&self) -> String;
-    ///Used to specify which fields to select
-    fn select_fields(&mut self, fields: Vec<&str>) -> &mut Self;
-
+    fn find(&self) -> &str;
     /// generate: INSERT INTO {table_name} ({struct_fields}) VALUES({$1,$2...}) RETURNING
     /// {struct_fields}
-    fn create(&mut self) -> String;
+    fn create(&mut self) -> &str;
     /// generate: UPDATE {table_name} SET struct_field1 = $1 , WHERE id = $2 RETURNING {struct_fields}
     /// {struct_fields}
-    fn update(&self) -> String;
+    fn update(&self) -> &str;
     ///generates: DELETE FROM {table_name} WHERE id = $1 RETURNING {struct_fields}
-    fn delete(&self) -> String;
+    fn delete(&self) -> &str;
 }
 
 #[allow(dead_code)]
@@ -70,21 +67,12 @@ mod tests {
     }
 
     #[test]
-    fn find_method_queries_specific_properties() {
-        assert_eq!(
-            "SELECT title, description FROM entity",
-            EntityOrm::builder()
-                .select_fields(vec!["title", "description"])
-                .find()
-        )
-    }
-
-    #[test]
     fn create_method_build_insert_sql_with_main_entity() {
         assert_eq!(
-        "INSERT INTO entity (title,description,others,another_property) VALUES ($1,$2,$3,$4) RETURNING id,title,description,others,another_property", 
-        EntityOrm::builder().create()
-        )
+    "INSERT INTO entity (title,description,others,another_property) VALUES ($1,$2,$3,$4) RETURNING
+    id,title,description,others,another_property",
+    EntityOrm::builder().create()
+    )
     }
 
     #[test]
@@ -95,21 +83,28 @@ mod tests {
         )
     }
 
-
     #[test]
     fn delete_method_build_delete_sql() {
         assert_eq!(
-        "DELETE FROM entity WHERE id = $1 RETURNING id,title,description,others,another_property",
-        EntityOrm::builder().delete()
-        )
+    "DELETE FROM entity WHERE id = $1 RETURNING id,title,description,others,another_property",
+    EntityOrm::builder().delete()
+    )
     }
 
     #[test]
     fn update_method_builds_sql() {
         assert_eq!(
-        "UPDATE entity SET title = $1,description = $2 WHERE id = $3 RETURNING id,title,description",
-        EntityUpdateDtoOrm::builder().update()
-        )
+    "UPDATE entity SET title = $1,description = $2 WHERE id = $3 RETURNING id,title,description",
+    EntityUpdateDtoOrm::builder().update()
+    )
     }
 
+    #[test]
+    fn update_method_builds_sql_with_main() {
+        assert_eq!(
+    "UPDATE entity SET title = $1,description = $2,others = $3, another_property = $4 WHERE id = $5 RETURNING
+    id,title,description,others,another_property",
+    EntityOrm::builder().update()
+    )
+    }
 }


### PR DESCRIPTION
This are the following changes: 

- All methods, except `find()` return &str instead of String, because I figured out how to do that
- now you can use mysql bindings `id = ?` `INSERT INTO table (field) VALUES(?)` by enabling the feature flag "mysql" , by default the flag enabled is "postgres" `id = $1` `ÌNSERT INTO table (field, field2) VALUES($1, $2)`

the method `select_fields` is now deprecated 