### PR TITLE
Release 1.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,4 @@ license = "MIT"
 
 
 [dependencies]
-orm_macro_derive = { version="1.2.1",  path = "./orm_macro_derive/" }
-
+orm_macro_derive = { version="1.2.1",  path = "./orm_macro_derive/" , features = ["postgres"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orm_macro"
-version = "1.2.1"
+version = "1.3.1"
 edition = "2021"
 authors = ["Josue <josuebarretogit@gmail.com>"]
 repository = "https://github.com/josueBarretogit/my_orm"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ license = "MIT"
 
 
 [dependencies]
-orm_macro_derive = { version="1.2.1",  path = "./orm_macro_derive/" , features = ["postgres"]}
+orm_macro_derive = { version="1.3.1",  path = "./orm_macro_derive/" }

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@ Tired of learning super complex Orms? bored of doing sqlbuilder.select("fields")
 sometimes you just want a quick, easy to use sql statement that matches your structs definitions even if it 
 changes, well this crate is for you 
 
+
+
+# Disclaimer
+
+I am new to rust and at the time I didn´t know how versioning works, so although the version says it's in 1.*.* this crate is still
+subject to changes
+
 # Table of contents
 
  1. [Installation](#Installation)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ changes, well this crate is for you
  1. [Installation](#Installation)
  2. [Usage](#Usage)
 * [Find method](#Find)
+* [Find by id](#Find-by-id)
 * [Create method](#Create)
 * [Update method](#Update)
 * [Delete method](#Delete)
@@ -16,8 +17,8 @@ changes, well this crate is for you
 
 put this in your cargo.toml: 
 ```rust 
-orm_macro = "1.2.1"
-orm_macro_derive = { version = "1.2.1", features = ["postgres"] }  
+orm_macro = "1.3.1"
+orm_macro_derive = { version = "1.3.1", features = ["postgres"] }  
 ```
 
 The feature flag  "postgres"  uses postgres style bindings, for example: 
@@ -27,8 +28,8 @@ DELETE FROM table WHERE id = ? # this bindings are used by mysql and sqlite
 ```
 If you want to use mysql bindings then in your cargo.toml
 ```rust
-orm_macro =  "1.2.1"
-orm_macro_derive = { version = "1.2.1", features = ["mysql"] } 
+orm_macro =  "1.3.1"
+orm_macro_derive = { version = "1.3.1", features = ["mysql"] } 
 ```
 
 ## Usage
@@ -40,11 +41,12 @@ use orm_macro_derive::GetRepository;
 
 //GetRepository will make a new struct with methods that 
 //build sql statements using your struct fields
-//The new struct will be named struct_nameOrm
+//The new struct will be named {yourStructName}Orm
 #[derive(Debug, Default, GetRepository)]
-#[table_name("books")]
+#[table_name(books)]
+#[id(id_books)] // Set the id of your table, this will be used in RETURNING and where clauses 
 pub struct Books {
-    pub id: i64,
+    pub id_books: i64,
     pub description: Option<String>,
     pub title: Option<String>,
     pub author_name : String,
@@ -52,14 +54,16 @@ pub struct Books {
 
 // works really well with Dto's
 #[derive(Debug, Default, GetRepository)]
-#[table_name("books")]
+#[table_name(books)]
+#[id(id_books)] // Set the id of your table, this will be used en the RETURNING clauses 
 pub struct BooksUpdateDto {
     pub description: Option<String>,
 }
 
 
 #[derive(Debug, Default, GetRepository)]
-#[table_name("books")]
+#[table_name(books)]
+#[id(id_books)] // Set the id of your table, this will be used en the RETURNING clauses 
 pub struct BooksCreateDto {
     pub title : String,
     pub description: Option<String>,
@@ -71,10 +75,15 @@ pub struct BooksCreateDto {
 ``` rust 
 async fn find_all() -> Result<Vec<Books>, sqlx::Error> {
 
-        /// this would generate: SELECT id,description,title FROM books 
+    
+        let builder = BooksOrm::builder();
+    
+
+        /// this would generate: SELECT id_books,description,title FROM books 
         ///since it is a string you can use it with any sql driver
-        let sql =  BooksOrm::builder().find();
-        let db_response = sqlx::query_as(sql.as_str())
+        let sql =  builder.find();
+
+        let db_response = sqlx::query_as(sql)
         .fetch_all(&executor)
         .await?;
 
@@ -83,15 +92,40 @@ async fn find_all() -> Result<Vec<Books>, sqlx::Error> {
 
  ```
 
+
+## Find by id
+
+``` rust 
+async fn find_by_id() -> Result<Vec<Books>, sqlx::Error> {
+
+    
+        let builder = BooksOrm::builder();
+    
+
+        ///this generates: SELECT id_books,description,title,author_name FROM books WHERE id_books = $1
+        ///This method will be named: find_by_{your_table_id}
+        let sql =  builder.find_by_id_books();
+
+        let db_response = sqlx::query_as(sql)
+        .fetch_all(&executor)
+        .await?;
+
+        Ok(db_response)
+  }
+
+ ```
+
+
+
 ## Create
 
 ```rust
 async fn create(&self, body : BooksCreateDto) -> Result<Vec<Books>, sqlx::Error> {
         let builder =  BooksCreateDtoOrm::builder();
 
-		/// this would generate: INSERT INTO books (title,description) VALUES($1,$2) RETURNING id,title,description
 		let sql = builder.create();
 
+		/// this would generate: INSERT INTO books (title,description) VALUES($1,$2) RETURNING id_books,title,description
         let db_response = sqlx::query_as(sql)
         .bind(body.title)
         .bind(body.description)
@@ -106,8 +140,9 @@ async fn create(&self, body : BooksCreateDto) -> Result<Vec<Books>, sqlx::Error>
 ```rust
     async fn update(body : BooksUpdateDto) -> Result<Vec<Books>, sqlx::Error> {
 
-        /// this would generate: UPDATE books SET description = $1 WHERE id = $2 RETURNING id, description
         let builder =  BooksUpdateDtoOrm::builder();
+
+        /// this would generate: UPDATE books SET description = $1 WHERE id_books = $2 RETURNING id_books, description
 		let sql = builder.update();
 
         let db_response = sqlx::query_as(sql))
@@ -123,8 +158,10 @@ async fn create(&self, body : BooksCreateDto) -> Result<Vec<Books>, sqlx::Error>
 
 ```rust
     async fn delete(id: i64) -> Result<Vec<Books>, sqlx::Error> {
+
         let builder =  BooksOrm::builder();
-		/// this would generate: DELETE FROM books WHERE id = $1  RETURNING id,title,description,author_name
+
+		/// this would generate: DELETE FROM books WHERE id_books = $1  RETURNING id_books,title,description,author_name
 		let sql = builder.delete();
 		
         let db_response = sqlx::query_as(sql)

--- a/orm_macro_derive/Cargo.toml
+++ b/orm_macro_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orm_macro_derive"
-version = "1.2.1"
+version = "1.3.1"
 edition = "2021"
 authors = ["Josue <josuebarretogit@gmail.com>"]
 repository = "https://github.com/josueBarretogit/my_orm"

--- a/orm_macro_derive/src/lib.rs
+++ b/orm_macro_derive/src/lib.rs
@@ -2,9 +2,9 @@ extern crate proc_macro;
 
 use core::panic;
 
-use proc_macro::{Span, TokenStream};
-use quote::{format_ident, quote, ToTokens};
-use syn::{parse_macro_input, Attribute, DeriveInput, Ident};
+use proc_macro::TokenStream;
+use quote::{format_ident, quote};
+use syn::{parse_macro_input, DeriveInput, Ident};
 use utils::*;
 
 mod utils;
@@ -49,7 +49,7 @@ pub fn get_repository(struc: TokenStream) -> TokenStream {
             .last()
             .map(|id| match &id.meta {
                 syn::Meta::List(data) => data.tokens.to_string(),
-                _ => panic!("the attribute should look like this:"),
+                _ => panic!("the attribute should look like this: #[id(your_table_id)]"),
             })
             .unwrap()
     } else {
@@ -235,18 +235,4 @@ fn impl_repository(struc_data: StructData) -> TokenStream {
 
     }
     .into()
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::utils::*;
-
-    #[test]
-    fn extracts_table_name() {
-        let attribute_from_struct = r#"table_name("table_name_extracted")"#;
-        assert_eq!(
-            "table_name_extracted",
-            extract_string_atribute(attribute_from_struct.to_string())
-        )
-    }
 }

--- a/orm_macro_derive/src/utils.rs
+++ b/orm_macro_derive/src/utils.rs
@@ -1,11 +1,3 @@
-/// The input will have the form: atribbute("atribbute to extract")
-pub fn extract_string_atribute(input: String) -> String {
-    let index_c1 = input.find('(').unwrap();
-    let index_c2 = input.find(')').unwrap();
-
-    input[(index_c1 + 1)..index_c2].replace("\"", "")
-}
-
 pub trait SqlBuilder {
     fn build_sql(self) -> String;
 }

--- a/orm_macro_derive/src/utils.rs
+++ b/orm_macro_derive/src/utils.rs
@@ -13,23 +13,21 @@ pub trait SqlBuilder {
 pub struct SelectStatement {
     select_fields: Vec<String>,
     from_table: String,
-    joins : Option<JoinsClause>,
+    joins: Option<JoinsClause>,
     where_clause: Option<WhereClause>,
 }
 
 impl SelectStatement {
-
     pub fn set_where(&mut self, where_clause: WhereClause) -> &mut Self {
         self.where_clause = Some(where_clause);
         self
     }
 
-
     pub fn new(select_fields: &Vec<String>, from_table: &str) -> Self {
         Self {
             select_fields: select_fields.to_owned(),
             from_table: from_table.to_owned(),
-            joins : None,
+            joins: None,
             where_clause: None,
         }
     }
@@ -62,7 +60,6 @@ pub struct JoinsClause {}
 impl JoinsClause {
     pub fn new() -> Self {
         Self {}
-
     }
 }
 
@@ -80,7 +77,7 @@ pub struct UpdateStatement {
 }
 
 impl UpdateStatement {
-    pub fn new(update_table_name: &str, where_clause : WhereClause) -> Self {
+    pub fn new(update_table_name: &str, where_clause: WhereClause) -> Self {
         Self {
             set_fields: String::new(),
             update_table_name: update_table_name.to_owned(),
@@ -89,43 +86,53 @@ impl UpdateStatement {
         }
     }
 
-    pub fn set_where(&mut self, conditions : Vec<String>) -> &mut Self {
+    pub fn set_where(&mut self, conditions: Vec<String>) -> &mut Self {
         self.where_clause.set_conditions(conditions);
         self
     }
 
     pub fn set_returning_clause(&mut self, returning_clause: ReturningClause) -> &mut Self {
-        self.returning_clause  = Some(returning_clause);
+        self.returning_clause = Some(returning_clause);
         self
     }
 
     #[cfg(not(feature = "postgres"))]
-    pub fn set_fields(&mut self, fields : Vec<String>) -> &mut Self { 
-        self.set_fields  = fields.iter().map(|field| format!("{} = ?,",  field)).collect();
+    pub fn set_fields(&mut self, fields: Vec<String>) -> &mut Self {
+        self.set_fields = fields
+            .iter()
+            .map(|field| format!("{} = ?,", field))
+            .collect();
         self.set_fields.pop();
         self
     }
-
 
     #[cfg(feature = "postgres")]
-    pub fn set_fields(&mut self, fields : Vec<String>) -> &mut Self { 
-        self.set_fields  = fields.iter().enumerate().map(|(index, field)| format!("{} = ${},",  field, index + 1)).collect();
+    pub fn set_fields(&mut self, fields: Vec<String>) -> &mut Self {
+        self.set_fields = fields
+            .iter()
+            .enumerate()
+            .map(|(index, field)| format!("{} = ${},", field, index + 1))
+            .collect();
         self.set_fields.pop();
         self
     }
-
 }
 
 impl SqlBuilder for UpdateStatement {
     fn build_sql(self) -> String {
-
         let returning_clause = if self.returning_clause.is_some() {
             self.returning_clause.unwrap().build_sql()
         } else {
             "".into()
         };
 
-        format!("UPDATE {} SET {} {} {}", self.update_table_name, self.set_fields, self.where_clause.build_sql(), returning_clause)
+        format!(
+            "UPDATE {} SET {} {} {}",
+            self.update_table_name,
+            self.set_fields,
+            self.where_clause.build_sql(),
+            returning_clause
+        )
     }
 }
 
@@ -137,8 +144,7 @@ pub struct InsertStatement {
 }
 
 impl InsertStatement {
-
-    pub fn new(table_name: &str, insert_fields: &Vec<String>, values : Vec<String>) -> Self {
+    pub fn new(table_name: &str, insert_fields: &Vec<String>, values: Vec<String>) -> Self {
         Self {
             table_name: table_name.to_owned(),
             insert_fields: insert_fields.to_owned(),
@@ -147,9 +153,7 @@ impl InsertStatement {
         }
     }
 
-
-
-    pub fn set_returning_clause(&mut self, returning_clause : ReturningClause) -> &mut Self {
+    pub fn set_returning_clause(&mut self, returning_clause: ReturningClause) -> &mut Self {
         self.returning_clause = Some(returning_clause);
         self
     }
@@ -157,35 +161,35 @@ impl InsertStatement {
 
 impl SqlBuilder for InsertStatement {
     fn build_sql(self) -> String {
+        let mut fields_to_insert = String::new();
+        let mut values_to_insert = String::new();
 
-        let mut fields_to_insert = String::new(); 
-        let mut values_to_insert = String::new(); 
+        self.insert_fields
+            .iter()
+            .enumerate()
+            .for_each(|(index, field)| {
+                fields_to_insert.push_str(format!("{},", field).as_str());
 
-        self.insert_fields.iter().enumerate().for_each(|(index, field)| {
+                #[cfg(feature = "postgres")]
+                values_to_insert.push_str(format!("${},", index + 1).as_str());
 
-            fields_to_insert.push_str(format!("{},", field).as_str());
-
-            #[cfg(feature = "postgres")]
-            values_to_insert.push_str(format!("${},", index + 1).as_str());
-
-            #[cfg(not(feature = "postgres"))]
-            values_to_insert.push_str("?,");
-
-
-        });
+                #[cfg(not(feature = "postgres"))]
+                values_to_insert.push_str("?,");
+            });
 
         fields_to_insert.pop();
         values_to_insert.pop();
 
-        
         let returning_clause = if self.returning_clause.is_some() {
             self.returning_clause.unwrap().build_sql()
         } else {
             "".into()
         };
 
-
-        format!("INSERT INTO {} ({}) VALUES ({}) {}", self.table_name, fields_to_insert, values_to_insert, returning_clause)
+        format!(
+            "INSERT INTO {} ({}) VALUES ({}) {}",
+            self.table_name, fields_to_insert, values_to_insert, returning_clause
+        )
     }
 }
 
@@ -204,49 +208,35 @@ impl DeleteStatement {
         }
     }
 
-    pub fn set_returning_clause(&mut self, returning_clause : ReturningClause)  -> &mut Self {
+    pub fn set_returning_clause(&mut self, returning_clause: ReturningClause) -> &mut Self {
         self.returning_clause = Some(returning_clause);
         self
     }
-
+    pub fn set_where_clause(&mut self, wheresqlclause: WhereClause) -> &mut Self {
+        self.where_clause = wheresqlclause;
+        self
+    }
 }
 
 impl SqlBuilder for DeleteStatement {
     fn build_sql(self) -> String {
-        
-        let mut where_clause = WhereClause::new();
-
-            #[cfg(feature = "postgres")]
-            where_clause
-            .set_conditions(vec!["id = $1".into()]);
-
-            #[cfg(not(feature = "postgres"))]
-            where_clause
-            .set_conditions(vec!["id = ?".into()]);
-
-
         let returning_clause = match self.returning_clause {
             Some(returning) => returning.build_sql(),
-            None => "".into()
+            None => "".into(),
         };
 
         format!(
             "DELETE FROM {} {} {}",
             self.table_name,
-            where_clause.build_sql(),
-        returning_clause
-        
-        
+            self.where_clause.build_sql(),
+            returning_clause
         )
     }
 }
 
-
-
 pub struct WhereClause {
     conditions: Vec<String>,
 }
-
 
 impl WhereClause {
     pub fn set_conditions(&mut self, conditions: Vec<String>) -> &mut Self {
@@ -262,30 +252,38 @@ impl WhereClause {
 
 impl SqlBuilder for WhereClause {
     fn build_sql(self) -> String {
-        let conditions : String = self.conditions.iter().map(|cond| cond.to_string()).collect();
+        let conditions: String = self
+            .conditions
+            .iter()
+            .map(|cond| cond.to_string())
+            .collect();
         format!("WHERE {}", conditions)
     }
 }
 
-
-
 pub struct ReturningClause {
+    id_table: String,
     fields: Vec<String>,
 }
 impl ReturningClause {
-    pub fn new(fields : &Vec<String>) -> Self {
-        Self { fields : fields.to_owned() }
+    pub fn new(fields: &Vec<String>, id_table: &str) -> Self {
+        Self {
+            id_table: id_table.to_owned(),
+            fields: fields.to_owned(),
+        }
     }
 }
 
 impl SqlBuilder for ReturningClause {
     fn build_sql(self) -> String {
-        let mut fields : String = self.fields.iter().map(|field| format!("{},", field)).collect();
+        let mut fields: String = self
+            .fields
+            .iter()
+            .filter(|field| **field != self.id_table)
+            .map(|field| format!("{},", field))
+            .collect();
         fields.pop();
-        
-        format!("RETURNING id,{}", fields)
+
+        format!("RETURNING {},{}", self.id_table, fields)
     }
 }
-
-
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,10 +3,7 @@ extern crate orm_macro_derive;
 ///This trait contains the methods that generate sql
 pub trait OrmRepository {
     /// generate: SELECT {struct_fields} from {table_name}
-    fn find(&self) -> String;
-    ///Used to specify which fields to select
-    #[deprecated(since="1.2.0", note="Removing this unnecesary method will make find() return &str instead of String, in the future there will be better find methods")]
-    fn select_fields(&mut self, fields: Vec<&str>) -> &mut Self;
+    fn find(&self) -> &str;
     /// generate: INSERT INTO {table_name} ({struct_fields}) VALUES({$1,$2...}) RETURNING
     /// {struct_fields}
     fn create(&self) -> &str;
@@ -24,7 +21,8 @@ mod tests {
     use crate::OrmRepository;
 
     #[derive(Default, orm_macro_derive::GetRepository)]
-    #[table_name("entity")]
+    #[table_name(entity)]
+    #[id(id)]
     struct Entity {
         id: i64,
         title: String,
@@ -34,21 +32,24 @@ mod tests {
     }
 
     #[derive(Default, orm_macro_derive::GetRepository)]
-    #[table_name("entity")]
+    #[table_name(entity)]
+    #[id(id)]
     struct EntityUpdateDto {
         title: String,
         description: String,
     }
 
     #[derive(Default, orm_macro_derive::GetRepository)]
-    #[table_name("entity")]
+    #[table_name(entity)]
+    #[id(id)]
     struct EntityFindDto {
         title: String,
         others: String,
     }
 
     #[derive(Default, orm_macro_derive::GetRepository)]
-    #[table_name("entity")]
+    #[table_name(entity)]
+    #[id(id)]
     struct EntityCreateDto {
         description: String,
     }
@@ -58,6 +59,24 @@ mod tests {
         assert_eq!(
             "SELECT title,others FROM entity ",
             EntityFindDtoOrm::builder().find()
+        )
+    }
+
+    #[cfg(feature = "postgres")]
+    #[test]
+    fn find_by_id_method_builds_sql_postgres() {
+        assert_eq!(
+            "SELECT title,others FROM entity WHERE id = $1",
+            EntityFindDtoOrm::builder().find_by_id()
+        )
+    }
+
+    #[cfg(not(feature = "postgres"))]
+    #[test]
+    fn find_by_id_method_builds_sql() {
+        assert_eq!(
+            "SELECT title,others FROM entity WHERE id = ?",
+            EntityFindDtoOrm::builder().find_by_id()
         )
     }
 
@@ -71,32 +90,12 @@ mod tests {
 
     #[cfg(feature = "postgres")]
     #[test]
-    fn create_method_build_insert_sql_with_main_entity() {
-        assert_eq!(
-    "INSERT INTO entity (title,description,others,another_property) VALUES ($1,$2,$3,$4) RETURNING id,title,description,others,another_property",
-    EntityOrm::builder().create()
-    )
-    }
-
-    #[cfg(not(feature = "postgres"))]
-    #[test]
-    fn create_method_build_insert_sql_with_main_entity_mysql_bindings() {
-        assert_eq!(
-    "INSERT INTO entity (title,description,others,another_property) VALUES (?,?,?,?) RETURNING id,title,description,others,another_property",
-    EntityOrm::builder().create()
-    )
-    }
-
-
-    #[cfg(feature = "postgres")]
-    #[test]
     fn create_method_build_insert_sql() {
         assert_eq!(
             "INSERT INTO entity (description) VALUES ($1) RETURNING id,description",
             EntityCreateDtoOrm::builder().create()
         )
     }
-
 
     #[cfg(not(feature = "postgres"))]
     #[test]
@@ -106,7 +105,6 @@ mod tests {
             EntityCreateDtoOrm::builder().create()
         )
     }
-
 
     #[cfg(feature = "postgres")]
     #[test]
@@ -126,7 +124,6 @@ mod tests {
     )
     }
 
-
     #[cfg(feature = "postgres")]
     #[test]
     fn update_method_builds_sql() {
@@ -134,7 +131,6 @@ mod tests {
     "UPDATE entity SET title = $1,description = $2 WHERE id = $3 RETURNING id,title,description",
     EntityUpdateDtoOrm::builder().update()
     )
-
     }
 
     #[cfg(not(feature = "postgres"))]
@@ -146,14 +142,11 @@ mod tests {
     )
     }
 
-
-
-
     #[cfg(feature = "postgres")]
     #[test]
     fn update_method_builds_sql_with_main() {
         assert_eq!(
-    "UPDATE entity SET title = $1,description = $2,others = $3,another_property = $4 WHERE id = $5 RETURNING id,title,description,others,another_property",
+    "UPDATE entity SET id = $1,title = $2,description = $3,others = $4,another_property = $5 WHERE id = $6 RETURNING id,title,description,others,another_property",
     EntityOrm::builder().update()
     )
     }
@@ -162,9 +155,8 @@ mod tests {
     #[test]
     fn test_update_query_with_mysql_binding() {
         assert_eq!(
-    "UPDATE entity SET title = ?,description = ?,others = ?,another_property = ? WHERE id = ? RETURNING id,title,description,others,another_property",
+    "UPDATE entity SET id = ?,title = ?,description = ?,others = ?,another_property = ? WHERE id = ? RETURNING id,title,description,others,another_property",
         EntityOrm::builder().update()
     )
     }
-
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ pub trait OrmRepository {
     fn select_fields(&mut self, fields: Vec<&str>) -> &mut Self;
     /// generate: INSERT INTO {table_name} ({struct_fields}) VALUES({$1,$2...}) RETURNING
     /// {struct_fields}
-    fn create(&mut self) -> &str;
+    fn create(&self) -> &str;
     /// generate: UPDATE {table_name} SET struct_field1 = $1 , WHERE id = $2 RETURNING {struct_fields}
     /// {struct_fields}
     fn update(&self) -> &str;


### PR DESCRIPTION
Whats new: 

`find` method now returns &str and the method `select_fields` no longer exists
now you can set the name of your table id, here is an example: 
```rust
#[table_name(books)]
#[id(id_books)] // Set the id of your table, this will be used en the RETURNING and WHERE clauses 
pub struct BooksUpdateDto {
    pub description: Option<String>,
}
```
Checkout the README for a detailed example 

 A new method was introduced `find_by_id`, it will be named find_by_{your_table_id} 
```rust
#[derive(Debug, Default, GetRepository)]
#[table_name(books)]
#[id(id_books)] // Set the id of your table, this will be used in RETURNING and where clauses 
pub struct Books {
    pub id_books: i64,
    pub description: Option<String>,
    pub title: Option<String>,
}

you can call: BooksOrm::builder().find_by_id_books()
```
Now if you forget to use the attributes required by de derive macro you will get a better error message

```rust
//compiler error
// proc-macro derive panicked message: #[table_name(your_table_name)] attribute is necessary to indicate which table the methods will affect
#[derive(Debug, Default, GetRepository)]
pub struct BooksUpdateDto {
    pub description: Option<String>,
}

```

